### PR TITLE
fix: record Gemini STT transcripts once

### DIFF
--- a/main.py
+++ b/main.py
@@ -90,6 +90,11 @@ class ExtraKeys:
     ACTIVE_TRIGGER: Final[str] = "_active_trigger"
     ACTIVE_REPLY_TRIGGERED: Final[str] = "active_reply_triggered"
     CURRENT_MESSAGE_RECORD: Final[str] = "_context_aware_current_message_record"
+    GEMINI_STT_TRANSCRIPT: Final[str] = "_gemini_stt_transcript"
+    GEMINI_STT_RAW_TEXT: Final[str] = "_gemini_stt_raw_text"
+    GEMINI_STT_CACHE_ONLY: Final[str] = "_gemini_stt_cache_only"
+    GEMINI_STT_SHOULD_REPLY: Final[str] = "_gemini_stt_should_reply"
+    GEMINI_STT_REPLY_REASON: Final[str] = "_gemini_stt_reply_reason"
     
     # 场景注入标记，防止重复注入
     SCENE_INJECTED_MARKER: Final[str] = "<!-- context_aware_scene_v3 -->"
@@ -225,6 +230,10 @@ def _clean_one_line(value: Any) -> str:
 
 def _event_message_outline(event: AstrMessageEvent) -> str:
     """优先使用 AstrBot 消息概要，以保留图片/语音等非文本消息占位。"""
+    transcript = _event_voice_transcript(event)
+    if transcript:
+        return transcript
+
     outline = ""
     try:
         outline = event.get_message_outline()
@@ -238,6 +247,23 @@ def _event_message_outline(event: AstrMessageEvent) -> str:
     if not outline:
         outline = str(getattr(event.message_obj, "message_str", "") or event.message_str or "")
     return _clean_one_line(outline)
+
+
+def _event_voice_transcript(event: AstrMessageEvent) -> str:
+    """读取 Gemini_STT 导出的语音转写，作为群聊上下文普通消息记录。"""
+    getter = getattr(event, "get_extra", None)
+    if not callable(getter):
+        return ""
+    try:
+        transcript = getter(ExtraKeys.GEMINI_STT_TRANSCRIPT, "") or getter(
+            ExtraKeys.GEMINI_STT_RAW_TEXT, ""
+        )
+    except Exception:
+        return ""
+    transcript = _clean_one_line(transcript)
+    if not transcript:
+        return ""
+    return f"[语音转写] {transcript}"
 
 
 def _looks_like_image_outline(text: str) -> bool:
@@ -414,6 +440,12 @@ class SessionManager:
         self._max_messages = max(10, max_messages)
         self._max_sessions = max(10, max_sessions)
 
+    def _has_message_id(self, state: SessionState, msg_id: str) -> bool:
+        normalized = str(msg_id or "").strip()
+        if not normalized:
+            return False
+        return any(existing.msg_id == normalized for existing in state.messages)
+
     def _get_lock(self, session_id: str) -> asyncio.Lock:
         """获取会话锁（惰性创建，使用 setdefault 保证原子性）"""
         # setdefault 是原子操作，避免竞态条件
@@ -459,13 +491,16 @@ class SessionManager:
         self._sessions[session_id] = state
         return state
 
-    async def add_message_async(self, session_id: str, msg: MessageRecord) -> None:
+    async def add_message_async(self, session_id: str, msg: MessageRecord) -> bool:
         """异步添加消息到会话（推荐使用，完全并发安全）"""
         async with self._get_lock(session_id):
             state = await self._get_or_create_session(session_id)
+            if self._has_message_id(state, msg.msg_id):
+                return False
             state.messages.append(msg)
             if not msg.is_bot:
                 state.last_user_interaction[msg.sender_id] = msg.timestamp
+            return True
 
     async def get_snapshot_async(self, session_id: str) -> SessionSnapshot:
         """获取会话快照（带会话锁）"""
@@ -526,15 +561,18 @@ class SessionManager:
                 return 0
             return len(state.messages)
 
-    def add_message(self, session_id: str, msg: MessageRecord) -> None:
+    def add_message(self, session_id: str, msg: MessageRecord) -> bool:
         """同步添加消息（向后兼容，但不推荐在并发场景使用）
         
         注意：此方法不提供完整的并发保护，仅用于向后兼容。
         """
         state = self.get(session_id)
+        if self._has_message_id(state, msg.msg_id):
+            return False
         state.messages.append(msg)
         if not msg.is_bot:
             state.last_user_interaction[msg.sender_id] = msg.timestamp
+        return True
 
     async def record_bot_response_async(
         self,
@@ -718,12 +756,13 @@ class SceneAnalyzer:
         """从事件提取消息记录"""
         sender_id = event.get_sender_id()
         message_outline = _event_message_outline(event)
+        voice_transcript = _event_voice_transcript(event)
         image_count = 0
         gif_count = 0
         has_plain_text = False
 
         # 提取消息内容，拼接所有文本和图片描述
-        content = event.message_str or ""
+        content = voice_transcript or event.message_str or ""
         if not content:
             # message_str 为空时，从消息组件中拼接
             parts: list[str] = []
@@ -1624,13 +1663,18 @@ class Main(star.Star):
         sender_id = event.get_sender_id()
         parts: list[str] = []
         message_outline = _event_message_outline(event)
+        voice_transcript = _event_voice_transcript(event)
         image_count = 0
         gif_count = 0
         has_plain_text = False
 
+        if voice_transcript:
+            parts.append(voice_transcript)
+            has_plain_text = True
+
         # 提取消息内容
         for comp in event.get_messages():
-            if isinstance(comp, Plain) and comp.text:
+            if isinstance(comp, Plain) and comp.text and not voice_transcript:
                 has_plain_text = True
                 parts.append(comp.text)
             elif isinstance(comp, Image):
@@ -1704,6 +1748,7 @@ class Main(star.Star):
         messages = event.get_messages()
         has_content = any(isinstance(c, (Plain, Image)) for c in messages)
         has_content = has_content or _looks_like_image_outline(message_outline)
+        has_content = has_content or bool(_event_voice_transcript(event))
         if not has_content:
             return
 
@@ -1742,8 +1787,9 @@ class Main(star.Star):
             )
 
         # v3.0.0: 使用异步方法确保并发安全
-        await self._sessions.add_message_async(event.unified_msg_origin, msg)
-        self._stats.messages_recorded += 1
+        added = await self._sessions.add_message_async(event.unified_msg_origin, msg)
+        if added:
+            self._stats.messages_recorded += 1
 
         # 每记录 50 条消息输出一次统计
         if self._stats.messages_recorded % 50 == 0:
@@ -1774,7 +1820,9 @@ class Main(star.Star):
         if not self._sessions.has_session(umo):
             # 使用支持图像转述的方法
             msg = await self._extract_message_with_caption(event)
-            await self._sessions.add_message_async(umo, msg)
+            added = await self._sessions.add_message_async(umo, msg)
+            if added:
+                self._stats.messages_recorded += 1
 
         try:
             snapshot = await self._sessions.get_snapshot_async(umo)

--- a/tests/test_gemini_stt_context.py
+++ b/tests/test_gemini_stt_context.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+PLUGIN_PATH = Path(__file__).resolve().parents[1] / "main.py"
+
+
+def _decorator(*args: Any, **kwargs: Any):
+    def wrap(func):
+        return func
+
+    return wrap
+
+
+def install_astrbot_stubs() -> dict[str, types.ModuleType]:
+    astrbot_mod = types.ModuleType("astrbot")
+    api_mod = types.ModuleType("astrbot.api")
+    event_mod = types.ModuleType("astrbot.api.event")
+    provider_mod = types.ModuleType("astrbot.api.provider")
+    message_components_mod = types.ModuleType("astrbot.api.message_components")
+    core_mod = types.ModuleType("astrbot.core")
+    agent_mod = types.ModuleType("astrbot.core.agent")
+    agent_message_mod = types.ModuleType("astrbot.core.agent.message")
+
+    class Logger:
+        def info(self, *args, **kwargs):
+            pass
+
+        def debug(self, *args, **kwargs):
+            pass
+
+        def warning(self, *args, **kwargs):
+            pass
+
+        def error(self, *args, **kwargs):
+            pass
+
+    class Star:
+        def __init__(self, context):
+            self.context = context
+
+    StarNamespace = types.SimpleNamespace(Star=Star, Context=object)
+
+    class PlatformAdapterType:
+        ALL = object()
+
+    FilterNamespace = types.SimpleNamespace(
+        PlatformAdapterType=PlatformAdapterType,
+        platform_adapter_type=_decorator,
+        on_llm_request=_decorator,
+        on_llm_response=_decorator,
+        after_message_sent=_decorator,
+    )
+
+    class TextPart:
+        def __init__(self, text: str):
+            self.text = text
+
+        def mark_as_temp(self):
+            return self
+
+    class Plain:
+        def __init__(self, text: str):
+            self.text = text
+
+    class Image:
+        def __init__(self, url: str = "", file: str = ""):
+            self.url = url
+            self.file = file
+
+    class At:
+        def __init__(self, qq: str, name: str = ""):
+            self.qq = qq
+            self.name = name
+
+    class AtAll:
+        pass
+
+    class Reply:
+        def __init__(self, sender_id: str = ""):
+            self.sender_id = sender_id
+
+    astrbot_mod.logger = Logger()
+    api_mod.star = StarNamespace
+    event_mod.AstrMessageEvent = object
+    event_mod.filter = FilterNamespace
+    class ProviderRequest:
+        def __init__(self):
+            self.system_prompt = ""
+            self.extra_user_content_parts = []
+
+    provider_mod.LLMResponse = object
+    provider_mod.Provider = object
+    provider_mod.ProviderRequest = ProviderRequest
+    agent_message_mod.TextPart = TextPart
+    message_components_mod.Plain = Plain
+    message_components_mod.Image = Image
+    message_components_mod.At = At
+    message_components_mod.AtAll = AtAll
+    message_components_mod.Reply = Reply
+
+    return {
+        "astrbot": astrbot_mod,
+        "astrbot.api": api_mod,
+        "astrbot.api.event": event_mod,
+        "astrbot.api.provider": provider_mod,
+        "astrbot.api.message_components": message_components_mod,
+        "astrbot.core": core_mod,
+        "astrbot.core.agent": agent_mod,
+        "astrbot.core.agent.message": agent_message_mod,
+    }
+
+
+def load_plugin_module():
+    with patch.dict(sys.modules, install_astrbot_stubs()):
+        spec = importlib.util.spec_from_file_location("context_aware_main", PLUGIN_PATH)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        sys.modules["context_aware_main"] = module
+        spec.loader.exec_module(module)
+        sys.modules.pop("context_aware_main", None)
+        return module
+
+
+class FakeContext:
+    def get_config(self, umo: str | None = None):
+        return {"wake_prefix": [], "provider_ltm_settings": {"group_icl_enable": False}}
+
+
+class FakeMessageObj:
+    message_id = "m1"
+    message = []
+
+
+class FakeEvent:
+    def __init__(self):
+        self.message_obj = FakeMessageObj()
+        self.message_str = ""
+        self.unified_msg_origin = "aiocqhttp:group:200"
+        self.extras = {
+            "_gemini_stt_transcript": "大家等会儿看一下这个配置",
+            "_gemini_stt_cache_only": True,
+        }
+
+    def get_extra(self, key, default=None):
+        return self.extras.get(key, default)
+
+    def set_extra(self, key, value):
+        self.extras[key] = value
+
+    def get_sender_id(self):
+        return "100"
+
+    def get_sender_name(self):
+        return "Alice"
+
+    def get_self_id(self):
+        return "bot"
+
+    def get_messages(self):
+        return []
+
+    def get_message_outline(self):
+        return ""
+
+    def get_message_str(self):
+        return ""
+
+    def is_private_chat(self):
+        return False
+
+
+class ContextAwareGeminiSTTTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.mod = load_plugin_module()
+
+    async def test_gemini_stt_transcript_is_recorded_as_message(self):
+        plugin = self.mod.Main(FakeContext(), {"enable": True, "only_group_chat": True})
+        event = FakeEvent()
+
+        await plugin.on_message(event)
+
+        messages = plugin.get_recent_messages(event.unified_msg_origin, count=1)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0]["content"], "[语音转写] 大家等会儿看一下这个配置")
+
+    async def test_voice_transcript_counts_as_content(self):
+        plugin = self.mod.Main(FakeContext(), {"enable": True, "only_group_chat": True})
+        event = FakeEvent()
+
+        await plugin.on_message(event)
+
+        self.assertTrue(plugin._sessions.has_session(event.unified_msg_origin))
+
+    async def test_llm_request_fallback_and_message_handler_do_not_duplicate_voice(self):
+        plugin = self.mod.Main(FakeContext(), {"enable": True, "only_group_chat": True})
+        event = FakeEvent()
+        req = self.mod.ProviderRequest()
+
+        await plugin.on_llm_request(event, req)
+        await plugin.on_message(event)
+
+        messages = plugin.get_recent_messages(event.unified_msg_origin, count=5)
+        voice_messages = [
+            msg
+            for msg in messages
+            if msg["content"] == "[语音转写] 大家等会儿看一下这个配置"
+        ]
+        self.assertEqual(len(voice_messages), 1)
+        self.assertEqual(plugin._stats.messages_recorded, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- record Gemini_STT voice transcripts as contextaware messages\n- deduplicate message insertion by non-empty message id\n- cover the LLM-request-before-message-handler ordering with a regression test\n\n## Tests\n- python3 -m py_compile main.py tests/test_gemini_stt_context.py\n- python3 -m unittest tests.test_gemini_stt_context